### PR TITLE
Update dependencies for newest ckeditor 5 version (11.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ckeditor5-super-sub-upd",
+  "name": "ckeditor5-super-sub",
   "version": "1.0.3",
   "description": "Superscript/subscript plugin for ckeditor5",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor5-super-sub-upd",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Superscript/subscript plugin for ckeditor5",
   "keywords": [
     "ckeditor5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ckeditor5-super-sub",
+  "name": "ckeditor5-super-sub-upd",
   "version": "1.0.2",
   "description": "Superscript/subscript plugin for ckeditor5",
   "keywords": [
@@ -17,6 +17,6 @@
   "license": "MIT",
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^11.1.0",
-    "@ckeditor/ckeditor5-ui": "^10.2.0"
+    "@ckeditor/ckeditor5-ui": "^11.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "mjadobson@gmail.com",
   "license": "MIT",
   "dependencies": {
-    "@ckeditor/ckeditor5-core": "^10.0.0",
-    "@ckeditor/ckeditor5-ui": "^10.0.0"
+    "@ckeditor/ckeditor5-core": "^11.1.0",
+    "@ckeditor/ckeditor5-ui": "^10.2.0"
   }
 }


### PR DESCRIPTION
The editor is broken when using the plugin with existing dependencies, with newest ckeditor 5 version 11.2.0. Updating them seems to solve the problem.